### PR TITLE
Support 503 retries, not_contains validator and delay function

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,38 @@ Same as the other test but running in interactive mode.
 ```python
 resttest.py https://api.github.com github_api_test.yaml --interactive true --print-bodies true
 ```
+## Adding delay to tests
+If the service your test requires some delay between requests you can add to the test definition a delay-parameter line which specifies the delay in seconds before running the HTTP-request.
+```yaml
+---
+- config:
+    - testset: "Test with delay"
+
+- test:
+    - name: "Ping a service with http"
+    - delay: 1.0
+    - url: /pingurl
+
+- test:
+    - name: "Ping a service with http"
+    - delay: 10.0
+    - url: /pingurl
+```
 
 ## Verbose Output
 
 ```shell
 resttest.py https://api.github.com github_api_test.yaml --log debug
+```
+
+## Retries
+
+If you test a service which may return HTTP/1.1 503 error codes indicating that the client should retry the request after some time you can add configuration option retries with the number of retries the test should try the request.
+
+The tester will use exponential (by 2) delays between tries.
+
+```shell
+resttest.py https://mytestservice.domain mytest.yaml --retries 5
 ```
 
 # Getting Started: Quickstart Requirements

--- a/advanced_guide.md
+++ b/advanced_guide.md
@@ -260,6 +260,7 @@ Optionally, validators can return a Failure which evaluates to False, but suppli
 | 'ge', 'greater_than_or_equal'                | Greater Than Or Equal To                  | A >= B                                                                 |
 | 'gt', 'greater_than'                         | Greater Than                              | A > B                                                                  |
 | 'contains'                                   | Contains                                  | B in A                                                                 |
+| 'not_contains'                               | Does not Contains                         | not B in A                                                             |
 | 'contained_by'                               | Contained By                              | A in B                                                                 |
 
 

--- a/pyresttest/resttest.py
+++ b/pyresttest/resttest.py
@@ -270,6 +270,10 @@ def run_test(mytest, test_config = TestConfig(), context = None):
             print "\n%s" % mytest.body
         raw_input("Press ENTER when ready: ")
 
+    if (mytest.delay > 0.0):
+        logger.debug("Delay sleeping " + str(mytest.delay) + " before HTTP request")
+        time.sleep(mytest.delay)
+
     retries = test_config.retries
     retry_sleep = 1.0
     while True:

--- a/pyresttest/tests.py
+++ b/pyresttest/tests.py
@@ -62,6 +62,7 @@ class Test(object):
     method = u'GET'
     group = u'Default'
     name = u'Unnamed'
+    delay = 0.0        # By default no delay before doing the request
     validators = None  # Validators for response body, IE regexes, etc
     stop_on_failure = False
     failures = None
@@ -339,6 +340,8 @@ class Test(object):
             elif configelement == u'name': #Test name
                 assert isinstance(configvalue,str) or isinstance(configvalue,unicode) or isinstance(configvalue,int)
                 mytest.name = unicode(configvalue,'UTF-8')
+            elif configelement == u'delay': #Test delay
+                mytest.delay = float(configvalue)
             elif configelement == u'extract_binds':
                 # Add a list of extractors, of format:
                 # {variable_name: {extractor_type: extractor_config}, ... }

--- a/pyresttest/validators.py
+++ b/pyresttest/validators.py
@@ -45,6 +45,7 @@ COMPARATORS = {
     'gt': operator.gt,
     'greater_than': operator.gt,
     'contains': lambda x,y: x and y and operator.contains(x,y), # is y in x
+    'not_contains': lambda x,y: x and y and not operator.contains(x,y), # not (is y in x)
     'contained_by': lambda x,y: x and y and operator.contains(y,x), # is x in y
 }
 


### PR DESCRIPTION
Three changes:
- support HTTP/1.X 503 with retry logic using base-2 exponential delays. Command line-option --retries N to limit number of retries
- added not_contains validator to check if B string is not found from the A
- added delay -function to have arbitratry delay before making the HTTP request