### PR TITLE
vars were not being processed for imported tests

### DIFF
--- a/pyresttest/resttest.py
+++ b/pyresttest/resttest.py
@@ -183,7 +183,7 @@ def parse_testsets(base_url, test_structure, test_files = set(), working_directo
                         test_files.add(importfile)
                         import_test_structure = read_test_file(importfile)
                         with cd(os.path.dirname(os.path.realpath(importfile))):
-                            import_testsets = parse_testsets(base_url, import_test_structure, test_files)
+                            import_testsets = parse_testsets(base_url, import_test_structure, test_files, vars=vars)
                             testsets.extend(import_testsets)
                 elif key == u'url': #Simple test, just a GET to a URL
                     mytest = Test()


### PR DESCRIPTION
When trying to make use of the --vars option in my tests I discovered it wasn't being passed from the cli into the imported test files. This should fix that. This let's me play this trick with running my tests:

```
pyresttest https:// testall.yaml --vars="{'domain':'example.com'}"
In suite1.yaml (which is imported in testall.yaml)
  - url: {template: "api.$domain/test"}
```

Since I have dozens of test environments but I need to be able to execute the same test suite against all of them.
