### PR TITLE
added a regex comparator

### DIFF
--- a/advanced_guide.md
+++ b/advanced_guide.md
@@ -264,6 +264,7 @@ Optionally, validators can return a Failure which evaluates to False, but suppli
 | 'gt', 'greater_than'                         | Greater Than                              | A > B                                                                  |
 | 'contains'                                   | Contains                                  | B in A                                                                 |
 | 'contained_by'                               | Contained By                              | A in B                                                                 |
+| 'regex'                                      | Regex Equals                              | A matches regex B                                                      |
 
 
 

--- a/pyresttest/validators.py
+++ b/pyresttest/validators.py
@@ -5,6 +5,7 @@ import traceback
 import string
 import parsing
 import os
+import re
 
 """
 Validator/Extractor logic for utility use
@@ -46,6 +47,7 @@ COMPARATORS = {
     'greater_than': operator.gt,
     'contains': lambda x,y: x and y and operator.contains(x,y), # is y in x
     'contained_by': lambda x,y: x and y and operator.contains(y,x), # is x in y
+    'regex': lambda x,y: regex_compare(str(x), str(y)),
 }
 
 # Unury comparison tests
@@ -66,6 +68,9 @@ def safe_length(var):
     except:
         pass
     return output
+
+def regex_compare(input,regex):
+    return bool(re.search(regex, input))
 
 # Validator Failure Reasons
 FAILURE_INVALID_RESPONSE = 'Invalid HTTP Response Code'


### PR DESCRIPTION
Do comparisons with a regex. Templating is supported.

Example usage:
```
    - compare: {jsonpath_mini: '.1.address', comparator: 'regex', expected: {template: 'api\.(environment_domain_suffix|$environment\.$domain)'}
```