### PR TITLE
Return the raw HTTP response

### DIFF
--- a/pyresttest/test_validators.py
+++ b/pyresttest/test_validators.py
@@ -89,6 +89,12 @@ class ValidatorsTest(unittest.TestCase):
         extract = validators.MiniJsonExtractor.parse(config)
         self.assertEqual(3, extract.extract(myjson, context=context))
 
+        # Return the same object
+        config = ''
+        extractor = validators.MiniJsonExtractor.parse(config)
+        extracted = extractor.extract(body=myjson)
+        self.assertEqual({'key': {'val': 3}}, extracted)
+
     def test_header_extractor(self):
         query = 'content-type'
         extractor = validators.HeaderExtractor.parse(query)

--- a/pyresttest/validators.py
+++ b/pyresttest/validators.py
@@ -165,7 +165,8 @@ class AbstractExtractor(object):
 
 class MiniJsonExtractor(AbstractExtractor):
     """ Extractor that uses jsonpath_mini syntax
-        IE key.key or array_index.key extraction
+        IE key.key or array_index.key extraction.
+        Returns the JSON object if no key.
     """
     extractor_type = 'jsonpath_mini'
     is_body_extractor = True
@@ -173,6 +174,8 @@ class MiniJsonExtractor(AbstractExtractor):
     def extract_internal(self, query=None, args=None, body=None, headers=None):
         try:
             body = json.loads(body)
+            if not query:
+                return body
             return self.query_dictionary(query, body)
         except ValueError:
             raise ValueError("Not legal JSON!")


### PR DESCRIPTION
In some cases you don't need to get any of the elements of the JSON object, but the object itself. I couldn't find the way to do that so I introduced a very small modification to the MiniJsonExtractor. If no key is specified, the whole object will be returned.