### PR TITLE
Add support for passing multiple test files as arguments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='pyresttest',
         'pyresttest.parsing', 'pyresttest.validators', 'pyresttest.contenthandling',
         'pyresttest.benchmarks','pyresttest.tests', 'pyresttest.ext.validator_jsonschema'],
     license='Apache License, Version 2.0',
-    requires=['yaml','pycurl'],
+    requires=['yaml', 'pycurl', 'argparse'],
     scripts=['util/pyresttest','util/resttest.py'], #Make this executable from command line when installed
     provides=['pyresttest']
 )


### PR DESCRIPTION
It replaces optparse with argparse (external dependency in Python 2.6) and allows to pass multiple files for the `--test` parameter. Wildcards and positional parameters will also work.