### PR TITLE
Fix: now able to set unicode bodies

### DIFF
--- a/pyresttest/tests.py
+++ b/pyresttest/tests.py
@@ -249,7 +249,7 @@ class Test(object):
         curl.setopt(curl.URL, str(self.url))
         curl.setopt(curl.TIMEOUT, timeout)
 
-        bod = self.body
+        bod = self.body.encode('unicode_escape') if self.body else None
 
         # Set read function for post/put bodies
         if bod and len(bod) > 0:


### PR DESCRIPTION
Example yaml, body contatins russian utf8 symbols:

- test:
    - name: "User login contains invalid chars"
    - group: "UserCreate"
    - url: "/user"
    - method: "POST"
    - headers: { Content-type: "application/json", Id: 4 }
    - body: '{"login":"user_петя","password":"pwd2"}'
    - expected_status: 400