### PR TITLE
Support for simple JSON extraction from the response body

### DIFF
--- a/pyresttest/validators.py
+++ b/pyresttest/validators.py
@@ -237,12 +237,14 @@ class MiniJsonExtractor(AbstractExtractor):
         # http://stackoverflow.com/questions/7320319/xpath-like-query-for-nested-python-dictionaries
 
         try:
-            for x in query.strip(delimiter).split(delimiter):
-                try:
-                    x = int(x)
-                    dictionary = dictionary[x]
-                except ValueError:
-                    dictionary = dictionary[x]
+            stripped_query = query.strip(delimiter)
+            if stripped_query:
+                for x in stripped_query.split(delimiter):
+                    try:
+                        x = int(x)
+                        dictionary = dictionary[x]
+                    except ValueError:
+                        dictionary = dictionary[x]
         except:
             return None
         return dictionary


### PR DESCRIPTION
I have an API that returns a JSON array in the response body. I want to test that it is, in fact, an array. Unfortunately, that doesn't seem to be possible. It's possible to test an element of the array, but not the whole array.

My test looks like this:

```
- test:
    - name: "Get all created streams and validate them"
    - url: {'template': "/api/v1/streams"}
    - expected_status: [200]
    - validators:
        - compare: {jsonpath_mini: "", comparator: 'type', expected: 'array'}
```

This fails because the `jsonpath_mini` spec causes the validator to actually test `(None, array)`. The reason is the logic in function `query_dictionary()`:

```
    def query_dictionary(query, dictionary, delimiter='.'):
        try:
            for x in query.strip(delimiter).split(delimiter):
                try:
                    x = int(x)
                    dictionary = dictionary[x]
                except ValueError:
                    dictionary = dictionary[x]
        except:
            return None
        return dictionary
```

If a blank string is used as a query, then the expression `query.strip(delimiter).split(delimiter)` returns an array one element long, containing a blank string. So, `dictionary=dictionary[x]` evaluates to `None`.

The suggested fix tests for an empty string and, if it finds one, simply returns the `dictionary` which, in this case, will be the full array. Hence, both subscripting of the array, as well as the full array, can be supported.

This is a general fix. A `jsonpath_mini` spec of an empty string simply causes the response body to be parsed as JSON and returned. So, you could test against anything.