### PR TITLE
Add setuptools as alternative for distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 
 setup(name='pyresttest',
       version='1.6.1.dev',


### PR DESCRIPTION
Hi @svanoort 

Thanks for made pyresttest, it's really useful to us.

I'm trying to contribute and resolve the issue #117, but I guess the setuptools to debug a python package and to distributing is most interesting than distutils. (example: `python setup.py develop`)

So, I opened this Pull Request for the pyresttest committers to use setuptools as alternative.

[]s