### PR TITLE
Add PATCH method to pycurl request

### DIFF
--- a/pyresttest/tests.py
+++ b/pyresttest/tests.py
@@ -37,6 +37,7 @@ DEFAULT_TIMEOUT = 10  # Seconds
 # Kind of obnoxious that it works this way...
 HTTP_METHODS = {u'GET': pycurl.HTTPGET,
                 u'PUT': pycurl.UPLOAD,
+                u'PATCH': pycurl.POSTFIELDS,
                 u'POST': pycurl.POST,
                 u'DELETE': 'DELETE'}
 
@@ -275,9 +276,17 @@ class Test(object):
                 curl.setopt(pycurl.INFILESIZE, len(bod))
             else:
                 curl.setopt(pycurl.INFILESIZE, 0)
+        elif self.method == u'PATCH':
+            curl.setopt(curl.POSTFIELDS, bod)
+            curl.setopt(curl.CUSTOMREQUEST, 'PATCH')
+            # Required for some servers
+            if bod is not None:
+                curl.setopt(pycurl.INFILESIZE, len(bod))
+            else:
+                curl.setopt(pycurl.INFILESIZE, 0)
         elif self.method == u'DELETE':
             curl.setopt(curl.CUSTOMREQUEST, 'DELETE')
-        elif self.method and self.method.upper() != 'GET':  # Support PATCH/HEAD/ETC
+        elif self.method and self.method.upper() != 'GET':  # Support HEAD/ETC
             curl.setopt(curl.CUSTOMREQUEST, self.method.upper())
 
         head = self.get_headers(context=context)


### PR DESCRIPTION
Hi @svanoort 

Thanks again for the great job with pyresttest and sorry for my poor english.
Anyway, this Pull Requests can solve #117 issue, now PATCH is really implement.

Please, check this example:
```
- test:
  - name: "Update an user from Contribution Details as admin"
  - url: "/contribution_details?id=eq.1"
  - headers: {'Content-Type': 'application/json'}
  - method: "PATCH"
  - body: '{"user_id": 2}'
  - expected_status: [204]
```

It's ours public API specs (you can check here https://github.com/catarse/catarse-api-specs) and running tests i've got this following error
```
test/contribution_details.yml...
{"message":"Failed to parse JSON payload. not enough input"}
[('transfer-encoding', 'chunked'), ('date', 'Tue, 15 Dec 2015 21:13:46 GMT'), ('server', 'postgrest/0.2.12.0'), ('content-type', 'application/json')]
ERROR:Test Failed: Update an user from Contribution Details as admin URL=http://localhost:8888/contribution_details?id=eq.1 Group=Default HTTP Status Code: 400
ERROR:Test Failure, failure type: Invalid HTTP Response Code, Reason: Invalid HTTP response code: response code 400 not in expected codes [[204]]
Test Group Default FAILED: 2/3 Tests Passed!
```

With this PR now this example works fine

```
test/contribution_details.yml...
Test Group Default SUCCEEDED: 3/3 Tests Passed!
```

Hope you like it :beers: 
