### PR TITLE
Allow ComparatorValidator to accept bytes input and work against unicode expected values

### DIFF
--- a/advanced_guide.md
+++ b/advanced_guide.md
@@ -240,6 +240,7 @@ Optionally, validators can return a Failure which evaluates to False, but suppli
 ### Extract And Compare:
 - **Name:** 'comparator' or 'compare' or 'assertEqual'
 - **Description:** run an extractor and compare results to expected value
+    + **Special note about encodings:** when testing raw binary bodies and strings for expected values, the expected value string is automatically encoded as UTF-8 bytes to allow for comparison. Use a !!bytes YAML if this is a problem, to avoid implicit encoding.
 - **Arguments:**
     + (extractor): an extractor definition, see above, named by extractor type
     + comparator: a comparator function to apply, which returns true or false (see list below)

--- a/pyresttest/test_validators.py
+++ b/pyresttest/test_validators.py
@@ -417,6 +417,30 @@ class ValidatorsTest(unittest.TestCase):
         self.assertTrue(comp_validator.validate(body=myjson_pass))
         self.assertFalse(comp_validator.validate(body=myjson_fail))
 
+    def test_validator_unicode_comparison(self):
+        """ Checks for implicit unicode -> byte conversion in testing """
+        config = {
+            'raw_body': '.',
+            'comparator': 'contains',
+            'expected': u'stuff'
+        }
+        comp_validator = validators.ComparatorValidator.parse(config)
+        myjson_pass = b'i contain stuff because win'
+        myjson_fail = b'i fail without it'
+        self.assertTrue(comp_validator.validate(body=myjson_pass))
+        self.assertFalse(comp_validator.validate(body=myjson_fail))
+
+        # Let's try this with unicode characters just for poops and giggles
+        config = {
+            'raw_body': '.',
+            'comparator': 'contains',
+            'expected': u'cat😽stuff'
+        }
+        myjson_pass = u'i contain cat😽stuff'.encode('utf-8')
+        myjson_pass_unicode = u'i contain encoded cat😽stuff'
+        self.assertTrue(comp_validator.validate(body=myjson_pass))
+        self.assertTrue(comp_validator.validate(body=myjson_pass_unicode))
+
     def test_validator_compare_ne(self):
         """ Basic test of the inequality validator"""
         config = {

--- a/pyresttest/validators.py
+++ b/pyresttest/validators.py
@@ -375,7 +375,11 @@ class ComparatorValidator(AbstractValidator):
         else:
             expected_val = self.expected
 
+        # Handle a bytes-based body and a unicode expected value seamlessly
+        if isinstance(extracted_val, binary_type) and isinstance(expected_val, text_type):
+            expected_val = expected_val.encode('utf-8')
         comparison = self.comparator(extracted_val, expected_val)
+
         if not comparison:
             failure = Failure(validator=self)
             failure.message = "Comparison failed, evaluating {0}({1}, {2}) returned False".format(


### PR DESCRIPTION
Completes issue https://github.com/svanoort/pyresttest/issues/127