### PR TITLE
Reuse curl handle where possible in tests

### DIFF
--- a/pyresttest/resttest.py
+++ b/pyresttest/resttest.py
@@ -303,7 +303,7 @@ def read_file(path):
     return string
 
 
-def run_test(mytest, test_config=TestConfig(), context=None):
+def run_test(mytest, test_config=TestConfig(), context=None, curl_handle=None, *args, **kwargs):
     """ Put together test pieces: configure & run actual test, return results """
 
     # Initialize a context if not supplied
@@ -314,7 +314,7 @@ def run_test(mytest, test_config=TestConfig(), context=None):
     mytest.update_context_before(my_context)
     templated_test = mytest.realize(my_context)
     curl = templated_test.configure_curl(
-        timeout=test_config.timeout, context=my_context)
+        timeout=test_config.timeout, context=my_context, curl_handle=curl_handle)
     result = TestResponse()
     result.test = templated_test
 
@@ -435,11 +435,10 @@ def run_test(mytest, test_config=TestConfig(), context=None):
     # TODO add string escape on body output
     logger.debug(result)
 
-    curl.close()
     return result
 
 
-def run_benchmark(benchmark, test_config=TestConfig(), context=None):
+def run_benchmark(benchmark, test_config=TestConfig(), context=None, *args, **kwargs):
     """ Perform a benchmark, (re)using a given, configured CURL call to do so
         The actual analysis of metrics is performed separately, to allow for testing
     """
@@ -514,7 +513,6 @@ def run_benchmark(benchmark, test_config=TestConfig(), context=None):
         for i in xrange(0, len(metricnames)):
             results[i].append(curl.getinfo(metricvalues[i]))
 
-    curl.close()
     logger.info('Benchmark: ' + message + ' ending')
 
     temp_results = dict()
@@ -623,6 +621,7 @@ def run_testsets(testsets):
     group_failure_counts = dict()
     total_failures = 0
     myinteractive = False
+    curl_handle = pycurl.Curl()
 
     for testset in testsets:
         mytests = testset.tests
@@ -652,7 +651,7 @@ def run_testsets(testsets):
                 group_results[test.group] = list()
                 group_failure_counts[test.group] = 0
 
-            result = run_test(test, test_config=myconfig, context=context)
+            result = run_test(test, test_config=myconfig, context=context, curl_handle=curl_handle)
             result.body = None  # Remove the body, save some memory!
 
             if not result.passed:  # Print failure, increase failure counts for that test group

--- a/pyresttest/tests.py
+++ b/pyresttest/tests.py
@@ -291,6 +291,16 @@ class Test(object):
 
         if curl_handle:
             curl = curl_handle
+
+            try:  # Check the curl handle isn't closed, and reuse it if possible
+                curl.getinfo(curl.HTTP_CODE)                
+                # Below clears the cookies & curl options for clean run
+                # But retains the DNS cache and connection pool
+                curl.reset()
+                curl.setopt(curl.COOKIELIST, "ALL")
+            except pycurl.error:
+                curl = pycurl.Curl()
+            
         else:
             curl = pycurl.Curl()
 


### PR DESCRIPTION
Solves an issue with DNS lookup being ridiculously slow when new handles are created.  

Reusing the handles allows use of a DNS cache and connection pool.  This greatly increases performance!

Should fix: https://github.com/svanoort/pyresttest/issues/152