### PR TITLE
Method fixes and enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## 1.7.0 Unreleased but on master branch (tentative Pip release in December/Jan)
 **Features:**
+* Unicode support epic: fix handling of request body and a whole raft of smaller fixes + more tests: https://github.com/svanoort/pyresttest/issues/104
 * ALPHA: Python 3 support - all tests now pass!
+  - 
 * JsonPath_Mini extractor supports ability to return the root response object now with the "." syntax -- thanks for the PR! https://github.com/svanoort/pyresttest/pull/106
 * Allow for smarter URL creation from fragments: https://github.com/svanoort/pyresttest/issues/118
-* Unicode support epic: fix handling of request body and a whole raft of smaller fixes + more tests: https://github.com/svanoort/pyresttest/issues/104
+
 * Add terminal output coloring for pass/pail (able to turn off via cmdline)
   - Thanks to @lerrua for his PRs  https://github.com/svanoort/pyresttest/pull/125 https://github.com/svanoort/pyresttest/pull/141
 
@@ -16,6 +18,10 @@
 * Fix HTTP PATCH method configuration - many thanks to @lerrua for his PR!
   - Noted in https://github.com/svanoort/pyresttest/issues/117
   - Fixed in https://github.com/svanoort/pyresttest/pull/129
+* Fix the HTTP DELETE use with a body, which could not be tested
+  - Thanks to @spradeepv for the pull request: https://github.com/svanoort/pyresttest/pull/165
+* Fix HTTP HEAD method configuration 
+  - Thanks to @ksramchandani for reporting issues that triggered an investigation (different root cause) in https://github.com/svanoort/pyresttest/issues/117
 
 **Known Issues / Back-Compatibility:**
 * Headers are returned from tests as unicode key, value pairs now

--- a/pyresttest/tests.py
+++ b/pyresttest/tests.py
@@ -349,6 +349,9 @@ class Test(object):
                 curl.setopt(pycurl.INFILESIZE, 0)
         elif self.method == u'DELETE':
             curl.setopt(curl.CUSTOMREQUEST, 'DELETE')
+        elif self.method == u'HEAD':
+            curl.setopt(curl.NOBODY, 1)
+            curl.setopt(curl.CUSTOMREQUEST, 'HEAD')
         elif self.method and self.method.upper() != 'GET':  # Support HEAD/ETC
             curl.setopt(curl.CUSTOMREQUEST, self.method.upper())
 

--- a/pyresttest/tests.py
+++ b/pyresttest/tests.py
@@ -349,14 +349,14 @@ class Test(object):
                 curl.setopt(pycurl.INFILESIZE, 0)
         elif self.method == u'DELETE':
             curl.setopt(curl.CUSTOMREQUEST, 'DELETE')
-            if body is not None:
+            if bod is not None:
                 curl.setopt(pycurl.INFILESIZE, len(bod))
         elif self.method == u'HEAD':
             curl.setopt(curl.NOBODY, 1)
             curl.setopt(curl.CUSTOMREQUEST, 'HEAD')
         elif self.method and self.method.upper() != 'GET':  # Alternate HTTP methods
             curl.setopt(curl.CUSTOMREQUEST, self.method.upper())
-            if body is not None:
+            if bod is not None:
                 curl.setopt(pycurl.INFILESIZE, len(bod))
 
         # Template headers as needed and convert headers dictionary to list of header entries

--- a/pyresttest/tests.py
+++ b/pyresttest/tests.py
@@ -349,11 +349,15 @@ class Test(object):
                 curl.setopt(pycurl.INFILESIZE, 0)
         elif self.method == u'DELETE':
             curl.setopt(curl.CUSTOMREQUEST, 'DELETE')
+            if body is not None:
+                curl.setopt(pycurl.INFILESIZE, len(bod))
         elif self.method == u'HEAD':
             curl.setopt(curl.NOBODY, 1)
             curl.setopt(curl.CUSTOMREQUEST, 'HEAD')
-        elif self.method and self.method.upper() != 'GET':  # Support HEAD/ETC
+        elif self.method and self.method.upper() != 'GET':  # Alternate HTTP methods
             curl.setopt(curl.CUSTOMREQUEST, self.method.upper())
+            if body is not None:
+                curl.setopt(pycurl.INFILESIZE, len(bod))
 
         # Template headers as needed and convert headers dictionary to list of header entries
         head = self.get_headers(context=context)


### PR DESCRIPTION
Fixes some of the custom HTTP methods that had alpha-level support in the last release and didn't always work correctly.  

Specifically: 
* HEAD, in some cases - https://github.com/svanoort/pyresttest/issues/117
* DELETE with request body - https://github.com/svanoort/pyresttest/issues/162