### PR TITLE
pyresttest command line works for MS Windows as well

### DIFF
--- a/pyresttest/command_line.py
+++ b/pyresttest/command_line.py
@@ -1,0 +1,5 @@
+import sys
+import pyresttest.resttest
+
+def main():
+    pyresttest.resttest.command_line_run(sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ setup(name='pyresttest',
       ],
       py_modules=['pyresttest.resttest', 'pyresttest.generators', 'pyresttest.binding',
                   'pyresttest.parsing', 'pyresttest.validators', 'pyresttest.contenthandling',
-                  'pyresttest.benchmarks', 'pyresttest.tests', 
-                  'pyresttest.six',
+                  'pyresttest.benchmarks', 'pyresttest.tests',
+                  'pyresttest.six','pyresttest.command_line',
                   'pyresttest.ext.validator_jsonschema',
                   'pyresttest.ext.extractor_jmespath'],
       license='Apache License, Version 2.0',
@@ -49,6 +49,8 @@ setup(name='pyresttest',
         'JMESPath': ['jmespath']
       },
       # Make this executable from command line when installed
-      scripts=['util/pyresttest', 'util/resttest.py'],
+      entry_points = {
+        'console_scripts': ['pyresttest=pyresttest.command_line:main'],
+      },
       provides=['pyresttest']
       )

--- a/util/pyresttest
+++ b/util/pyresttest
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-import sys
-from pyresttest import resttest
-resttest.command_line_run(sys.argv[1:])


### PR DESCRIPTION
The command line 'pyresttest' in the scripts folder is now works for MS Windows as well. Tested on my MAC OSx as well.