### PR TITLE
Case insensitive string comparator

### DIFF
--- a/advanced_guide.md
+++ b/advanced_guide.md
@@ -349,6 +349,7 @@ Optionally, validators can return a Failure which evaluates to False, but suppli
 | 'le', 'less_than_or_equal'                   | Less Than Or Equal To                     | A <= B                                                                 |
 | 'eq', 'equals'                               | Equals                                    | A == B                                                                 |
 | 'str_eq'                                     | Values are Equal When Converted to String | str(A) == str(B) -- useful for comparing templated numbers/collections |
+| 'str_eq_insensitive'                         | Case Insensitive version of str_eq        | str(A).lower() == str(B).lower()                                       |
 | 'ne', 'not_equals'                           | Not Equals                                | A != B                                                                 |
 | 'ge', 'greater_than_or_equal'                | Greater Than Or Equal To                  | A >= B                                                                 |
 | 'gt', 'greater_than'                         | Greater Than                              | A > B                                                                  |

--- a/pyresttest/test_validators.py
+++ b/pyresttest/test_validators.py
@@ -577,5 +577,36 @@ class ValidatorsTest(unittest.TestCase):
         self.assertEqual(validation_result.message,
                          "Extract and test validator failed on test: exists(None)")
 
+    def test_validator_string_comparison(self):
+        """ Tests string comparison """
+        config = {
+            'jsonpath_mini': 'key.val',
+            'comparator': 'str_eq',
+            'expected': "data"
+        }
+        comp_validator = validators.ComparatorValidator.parse(config)
+        myjson_pass = '{"id": 3, "key": {"val": "data"}}'
+        myjson_fail = '{"id": 3, "key": {"val": "DATA"}}'
+
+        self.assertTrue(comp_validator.validate(body=myjson_pass))
+        self.assertFalse(comp_validator.validate(body=myjson_fail))
+
+    def test_validator_string_comparison(self):
+        """ Tests case-insensitive string comparison """
+        config = {
+            'jsonpath_mini': 'key.val',
+            'comparator': 'str_eq_insensitive',
+            'expected': "data"
+        }
+        comp_validator = validators.ComparatorValidator.parse(config)
+        myjson_lowercase = '{"id": 3, "key": {"val": "data"}}'
+        myjson_uppercase = '{"id": 3, "key": {"val": "DATA"}}'
+        myjson_mixcase = '{"id": 3, "key": {"val": "DaTa"}}'
+
+        self.assertTrue(comp_validator.validate(body=myjson_lowercase))
+        self.assertTrue(comp_validator.validate(body=myjson_uppercase))
+        self.assertTrue(comp_validator.validate(body=myjson_mixcase))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/pyresttest/validators.py
+++ b/pyresttest/validators.py
@@ -53,6 +53,7 @@ COMPARATORS = {
     'eq': operator.eq,
     'equals': operator.eq,
     'str_eq': lambda x, y: operator.eq(str(x), str(y)),
+    'str_eq_insensitive': lambda x, y: operator.eq(str(x).lower(), str(y).lower()),
     'ne': operator.ne,
     'not_equals': operator.ne,
     'ge': operator.ge,


### PR DESCRIPTION
Implementation of case insensitive comparator as described in issue #148  

Utilizing built-in str.lower() for implementation assuming mostly english character set