### PR TITLE
Fix "SSL certificate problem" by using certifi

### DIFF
--- a/pyresttest/resttest.py
+++ b/pyresttest/resttest.py
@@ -5,6 +5,7 @@ import inspect
 import traceback
 import yaml
 import pycurl
+import certifi
 import json
 import csv
 import logging
@@ -324,6 +325,7 @@ def run_test(mytest, test_config=TestConfig(), context=None, curl_handle=None, *
     # reset the body, it holds values from previous runs otherwise
     headers = MyIO()
     body = MyIO()
+    curl.setopt(pycurl.CAINFO, certifi.where())
     curl.setopt(pycurl.WRITEFUNCTION, body.write)
     curl.setopt(pycurl.HEADERFUNCTION, headers.write)
     if test_config.verbose:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
     from distutils.core import setup
 
 # Future is needed for pip distribution for python 3 support
-dependencies = ['pyyaml', 'pycurl']
+dependencies = ['pyyaml', 'pycurl', 'certifi']
 test_dependencies = ['django==1.6.5','django-tastypie==0.12.1','jsonpath','jmespath']
 
 # Add additional compatibility shims


### PR DESCRIPTION
I got this error but target website have a valid certificate.
```
error: (60, 'SSL certificate problem: self signed certificate in certificate chain')
```
related to Issues #46.

I solved by using `certifi` package which is basically an up-to-date copy of mozilla's built in certificate. Merge if you need, thanks.

Reference:
https://stackoverflow.com/questions/16192832/pycurl-https-error-unable-to-get-local-issuer-certificate
https://stackoverflow.com/questions/27804710/python-urllib2-ssl-error/27826829#27826829