### PR TITLE
Print test case detail with its status

### DIFF
--- a/pyresttest/resttest.py
+++ b/pyresttest/resttest.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import sys
 import os
 import inspect
@@ -622,6 +623,7 @@ def run_testsets(testsets):
     """ Execute a set of tests, using given TestSet list input """
     group_results = dict()  # results, by group
     group_failure_counts = dict()
+    group_test_case_results = dict()
     total_failures = 0
     myinteractive = False
     curl_handle = pycurl.Curl()
@@ -652,6 +654,7 @@ def run_testsets(testsets):
             # Initialize the dictionaries to store test fail counts and results
             if test.group not in group_results:
                 group_results[test.group] = list()
+                group_test_case_results[test.group] = list()
                 group_failure_counts[test.group] = 0
 
             result = run_test(test, test_config=myconfig, context=context, curl_handle=curl_handle)
@@ -661,6 +664,7 @@ def run_testsets(testsets):
                 # Use result test URL to allow for templating
                 logger.error('Test Failed: ' + test.name + " URL=" + result.test.url +
                              " Group=" + test.group + " HTTP Status Code: " + str(result.response_code))
+                status = 'FAILED'
 
                 # Print test failure reasons
                 if result.failures:
@@ -675,11 +679,13 @@ def run_testsets(testsets):
                 group_failure_counts[test.group] = failures
 
             else:  # Test passed, print results
+                status = 'Passed'
                 logger.info('Test Succeeded: ' + test.name +
                             " URL=" + test.url + " Group=" + test.group)
 
             # Add results for this test group to the resultset
             group_results[test.group].append(result)
+            group_test_case_results[test.group].append({'test_case_name': test.name, 'status': status})
 
             # handle stop_on_failure flag
             if not result.passed and test.stop_on_failure is not None and test.stop_on_failure:
@@ -720,6 +726,7 @@ def run_testsets(testsets):
         test_count = len(group_results[group])
         failures = group_failure_counts[group]
         total_failures = total_failures + failures
+        group_test_case = group_test_case_results[group]
 
         passfail = {True: u'SUCCEEDED: ', False: u'FAILED: '}
         output_string = "Test Group {0} {1}: {2}/{3} Tests Passed!".format(group, passfail[failures == 0], str(test_count - failures), str(test_count)) 
@@ -731,6 +738,18 @@ def run_testsets(testsets):
                 print('\033[91m' + output_string + '\033[0m')
             else:
                 print('\033[92m' + output_string + '\033[0m')
+        for single_test_case in group_test_case:
+            sub_test_case = "{0} -- {1}".format(single_test_case['test_case_name'],single_test_case['status'])
+            if single_test_case['status'] == 'Passed':
+                if myconfig.skip_term_colors:
+                    print(sub_test_case)
+                else:       
+                    print('\033[90m' + sub_test_case + '\033[0m')
+            else:
+                if myconfig.skip_term_colors:
+                    print(sub_test_case)
+                else:       
+                    print('\033[91m' + sub_test_case + '\033[0m')
 
     return total_failures
 

--- a/pyresttest/resttest.py
+++ b/pyresttest/resttest.py
@@ -738,18 +738,19 @@ def run_testsets(testsets):
                 print('\033[91m' + output_string + '\033[0m')
             else:
                 print('\033[92m' + output_string + '\033[0m')
-        for single_test_case in group_test_case:
-            sub_test_case = "{0} -- {1}".format(single_test_case['test_case_name'],single_test_case['status'])
-            if single_test_case['status'] == 'Passed':
-                if myconfig.skip_term_colors:
-                    print(sub_test_case)
-                else:       
-                    print('\033[90m' + sub_test_case + '\033[0m')
-            else:
-                if myconfig.skip_term_colors:
-                    print(sub_test_case)
-                else:       
-                    print('\033[91m' + sub_test_case + '\033[0m')
+        if myconfig.print_detail_testcases:
+            for single_test_case in group_test_case:
+                sub_test_case = "{0} -- {1}".format(single_test_case['test_case_name'],single_test_case['status'])
+                if single_test_case['status'] == 'Passed':
+                    if myconfig.skip_term_colors:
+                        print(sub_test_case)
+                    else:       
+                        print('\033[90m' + sub_test_case + '\033[0m')
+                else:
+                    if myconfig.skip_term_colors:
+                        print(sub_test_case)
+                    else:       
+                        print('\033[91m' + sub_test_case + '\033[0m')
 
     return total_failures
 
@@ -818,6 +819,7 @@ def main(args):
         interactive   - OPTIONAL - mode that prints info before and after test exectuion and pauses for user input for each test
         absolute_urls - OPTIONAL - mode that treats URLs in tests as absolute/full URLs instead of relative URLs
         skip_term_colors - OPTIONAL - mode that turn off the output term colors
+        print_detail_testcases - OPTIONAL - print test case detail with its status
     """
 
     if 'log' in args and args['log'] is not None:
@@ -871,6 +873,10 @@ def main(args):
         if 'skip_term_colors' in args and args['skip_term_colors'] is not None:
             t.config.skip_term_colors = safe_to_bool(args['skip_term_colors'])
 
+        if 'print_detail_testcases' in args and args['print_detail_testcases'] is not None:
+            t.config.print_detail_testcases = safe_to_bool(args['print_detail_testcases'])
+
+
     # Execute all testsets
     failures = run_testsets(tests)
 
@@ -905,6 +911,8 @@ def parse_command_line_args(args_in):
                       action="store_true", dest="absolute_urls")
     parser.add_option(u'--skip_term_colors', help='Turn off the output term colors',
                       action='store_true', default=False, dest="skip_term_colors")
+    parser.add_option(u'--print_detail_testcases', help='Print test case detail with its status.',
+                      action='store_true', default=False, dest="print_detail_testcases")
 
     (args, unparsed_args) = parser.parse_args(args_in)
     args = vars(args)


### PR DESCRIPTION
Enchence from **sohamnavadiya**'s pull request https://github.com/svanoort/pyresttest/pull/222
- Add an options `--print_detail_testcases` and put the print logic in to reserve elasticity.
- Let printing support `--skip_term_colors` tag.
- Some code cleanup.

Related to issue #213.