### PR TITLE
Fix Windows unittests and color output

### DIFF
--- a/pyresttest/resttest.py
+++ b/pyresttest/resttest.py
@@ -856,6 +856,16 @@ def main(args):
 
         if 'skip_term_colors' in args and args['skip_term_colors'] is not None:
             t.config.skip_term_colors = safe_to_bool(args['skip_term_colors'])
+            if not t.config.skip_term_colors:
+                try:
+                    from colorama import init as colorama_init
+                except ImportError:
+                    if sys.platform == 'win32':
+                        logger.warn('Terminal colors on Windows require the colorama package. '
+                                    '`pip install colorama` to enable. Colors will be disabled.')
+                        t.config.skip_term_colors = True
+                else:  # run colorama_init() only if the import was successful
+                    colorama_init()
 
     # Execute all testsets
     failures = run_testsets(tests)

--- a/pyresttest/test_contenthandling.py
+++ b/pyresttest/test_contenthandling.py
@@ -138,7 +138,7 @@ class ContentHandlerTest(unittest.TestCase):
         """ Test parsing of file content """
         node = {'file': '/myval'}
         handler = ContentHandler.parse_content(node)
-        self.assertEqual(node['file'], handler.content)
+        self.assertEqual(os.path.abspath(node['file']), handler.content)
         self.assertFalse(handler.is_dynamic())
         self.assertTrue(handler.is_file)
         self.assertFalse(handler.is_template_path)
@@ -169,7 +169,7 @@ class ContentHandlerTest(unittest.TestCase):
         """ Test parsing of templated file path """
         node = {'file': {'template': '/$host-path.yaml'}}
         handler = ContentHandler.parse_content(node)
-        self.assertEqual('/$host-path.yaml', handler.content)
+        self.assertEqual(os.path.abspath('/$host-path.yaml'), handler.content)
         self.assertTrue(handler.is_dynamic())
         self.assertTrue(handler.is_file)
         self.assertTrue(handler.is_template_path)
@@ -179,7 +179,7 @@ class ContentHandlerTest(unittest.TestCase):
         """ Test parsing of templated file content """
         node = {'template': {'file': '/path.yaml'}}
         handler = ContentHandler.parse_content(node)
-        self.assertEqual('/path.yaml', handler.content)
+        self.assertEqual(os.path.abspath('/path.yaml'), handler.content)
         self.assertTrue(handler.is_dynamic())
         self.assertTrue(handler.is_file)
         self.assertFalse(handler.is_template_path)
@@ -189,7 +189,7 @@ class ContentHandlerTest(unittest.TestCase):
         """ Test parsing of file with path and content templated """
         node = {'template': {'file': {'template': '/$var-path.yaml'}}}
         handler = ContentHandler.parse_content(node)
-        self.assertEqual('/$var-path.yaml', handler.content)
+        self.assertEqual(os.path.abspath('/$var-path.yaml'), handler.content)
         self.assertTrue(handler.is_dynamic())
         self.assertTrue(handler.is_file)
         self.assertTrue(handler.is_template_path)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
     from distutils.core import setup
 
 # Future is needed for pip distribution for python 3 support
-dependencies = ['pyyaml', 'pycurl']
+dependencies = ['pyyaml', 'pycurl', 'colorama;platform_system=="Windows"']
 test_dependencies = ['django==1.6.5','django-tastypie==0.12.1','jsonpath','jmespath']
 
 # Add additional compatibility shims


### PR DESCRIPTION
Uses the `os.path.abspath()` function to fix tests that were failing on the Windows platform.

Fixes color output on the Windows terminal.

No longer need --skip-term-colors as mentioned in issue #235