### PR TITLE
Fix for `fixed_sequence`, and fix for an output bug.

### DIFF
--- a/pyresttest/generators.py
+++ b/pyresttest/generators.py
@@ -97,6 +97,7 @@ def factory_fixed_sequence(values):
         i = 0
         while(True):
             yield my_list[i]
+            i += 1
             if i == len(my_list):
                 i = 0
     return seq_generator

--- a/pyresttest/validators.py
+++ b/pyresttest/validators.py
@@ -382,8 +382,13 @@ class ComparatorValidator(AbstractValidator):
 
         if not comparison:
             failure = Failure(validator=self)
+            
+            output_extracted_val = extracted_val
+            if self.comparator_name in ("count_eq", "length_eq"):
+                output_extracted_val = len(extracted_val)
+
             failure.message = "Comparison failed, evaluating {0}({1}, {2}) returned False".format(
-                self.comparator_name, extracted_val, expected_val)
+                self.comparator_name, output_extracted_val, expected_val)
             failure.details = self.get_readable_config(context=context)
             failure.failure_type = FAILURE_VALIDATOR_FAILED
             return failure


### PR DESCRIPTION
• Improves output of count/lenth_eq failures.
• Fixes the `fixed_sequence` generator to actually work (currently takes only the first element from the `values` array).