### PR TITLE
Fix missing curl.close() in run_test

### DIFF
--- a/pyresttest/resttest.py
+++ b/pyresttest/resttest.py
@@ -442,6 +442,7 @@ def run_test(mytest, test_config=TestConfig(), context=None, curl_handle=None, *
 
     # TODO add string escape on body output
     logger.debug(result)
+    curl.close()
 
     return result
 


### PR DESCRIPTION
There was a missing `curl.close()` at the end of `run_test` method. This creates issue with FastAPI framework, see this gist: https://gist.github.com/Methacrylon/79b284bd6d357a1bfd1d942a9a8abfc2